### PR TITLE
Make Connectional trait object safe

### DIFF
--- a/src/connector/mysql.rs
+++ b/src/connector/mysql.rs
@@ -58,6 +58,23 @@ impl Connectional for Mysql {
         let result = f(&mut conn);
         result
     }
+
+    fn execute_on_connection(&self, db: &str, query: Query) -> QueryResult<Option<Id>> {
+        self.with_connection(&db, |conn| conn.execute(query))
+    }
+
+    fn query_on_connection(&self, db: &str, query: Query) -> QueryResult<ResultSet> {
+        self.with_connection(&db, |conn| conn.query(query))
+    }
+
+    fn query_on_raw_connection(
+        &self,
+        db: &str,
+        sql: &str,
+        params: &[ParameterizedValue],
+    ) -> QueryResult<ResultSet> {
+        self.with_connection(&db, |conn| conn.query_raw(&sql, &params))
+    }
 }
 
 fn conv_params(params: &[ParameterizedValue]) -> my::params::Params {

--- a/src/connector/mysql.rs
+++ b/src/connector/mysql.rs
@@ -52,6 +52,7 @@ impl Connectional for Mysql {
     fn with_connection<F, T>(&self, _db: &str, f: F) -> QueryResult<T>
     where
         F: FnOnce(&mut Connection) -> QueryResult<T>,
+        Self: Sized,
     {
         dbg!(self.pool.state());
         let mut conn = self.pool.get()?;

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -82,6 +82,23 @@ impl Connectional for PostgreSql {
             result
         })
     }
+
+    fn execute_on_connection(&self, db: &str, query: Query) -> QueryResult<Option<Id>> {
+        self.with_connection(&db, |conn| conn.execute(query))
+    }
+
+    fn query_on_connection(&self, db: &str, query: Query) -> QueryResult<ResultSet> {
+        self.with_connection(&db, |conn| conn.query(query))
+    }
+
+    fn query_on_raw_connection(
+        &self,
+        db: &str,
+        sql: &str,
+        params: &[ParameterizedValue],
+    ) -> QueryResult<ResultSet> {
+        self.with_connection(&db, |conn| conn.query_raw(&sql, &params))
+    }
 }
 
 impl<'a> Transaction for PostgresTransaction<'a> {}

--- a/src/connector/postgres.rs
+++ b/src/connector/postgres.rs
@@ -75,6 +75,7 @@ impl Connectional for PostgreSql {
     fn with_connection<F, T>(&self, _db: &str, f: F) -> QueryResult<T>
     where
         F: FnOnce(&mut Connection) -> QueryResult<T>,
+        Self: Sized,
     {
         // TODO: Select DB.
         self.with_connection_internal(|mut client| {

--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -53,6 +53,23 @@ impl Connectional for Sqlite {
     {
         self.with_connection_internal(db, |c| f(c.get_mut()))
     }
+
+    fn execute_on_connection(&self, db: &str, query: Query) -> QueryResult<Option<Id>> {
+        self.with_connection(&db, |conn| conn.execute(query))
+    }
+
+    fn query_on_connection(&self, db: &str, query: Query) -> QueryResult<ResultSet> {
+        self.with_connection(&db, |conn| conn.query(query))
+    }
+
+    fn query_on_raw_connection(
+        &self,
+        db: &str,
+        sql: &str,
+        params: &[ParameterizedValue],
+    ) -> QueryResult<ResultSet> {
+        self.with_connection(&db, |conn| conn.query_raw(&sql, &params))
+    }
 }
 
 // Concrete implmentations of trait methods, dropping the mut

--- a/src/connector/sqlite.rs
+++ b/src/connector/sqlite.rs
@@ -50,6 +50,7 @@ impl Connectional for Sqlite {
     fn with_connection<F, T>(&self, db: &str, f: F) -> QueryResult<T>
     where
         F: FnOnce(&mut Connection) -> QueryResult<T>,
+        Self: Sized,
     {
         self.with_connection_internal(db, |c| f(c.get_mut()))
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -45,7 +45,19 @@ pub trait Connectional {
     /// or schema mutations.
     fn with_connection<F, T>(&self, db: &str, f: F) -> QueryResult<T>
     where
-        F: FnOnce(&mut Connection) -> QueryResult<T>;
+        F: FnOnce(&mut Connection) -> QueryResult<T>,
+        Self: Sized;
+
+    fn execute_on_connection(&self, db: &str, query: Query) -> QueryResult<Option<Id>>;
+
+    fn query_on_connection(&self, db: &str, query: Query) -> QueryResult<ResultSet>;
+
+    fn query_on_raw_connection(
+        &self,
+        db: &str,
+        sql: &str,
+        params: &[ParameterizedValue],
+    ) -> QueryResult<ResultSet>;
 }
 
 pub trait Transactional {


### PR DESCRIPTION
This PR makes the trait `Connectional` object safe meaning it was not possible to use a `Box<Connectional>` or `Arc<Connectional>`. It was not object safe before as it used generic type parameters in its one method `with_connection`. This PR uses techniques described in `rustc --explain E0038` to fix this issue.

The resulting changes of this fix can be seen here: https://github.com/prisma/prisma/pull/4656