### PR TITLE
ParameterizedValue: Add method into_vec

### DIFF
--- a/src/ast/values.rs
+++ b/src/ast/values.rs
@@ -1,5 +1,7 @@
 use crate::ast::*;
+use crate::error::Error;
 use std::borrow::{Borrow, Cow};
+use std::convert::TryFrom;
 
 #[cfg(feature = "json-1")]
 use serde_json::{Number, Value};
@@ -204,6 +206,25 @@ impl<'a> ParameterizedValue<'a> {
             _ => None,
         }
     }
+
+    /// Returns a Vec<T> if the value is an array of T, otherwise `None`.
+    pub fn into_vec<T>(self) -> Option<Vec<T>> where
+        // Implement From<ParameterizedValue>
+        T: TryFrom<ParameterizedValue<'a>>
+    {
+        match self {
+            ParameterizedValue::Array(vec) => {
+                let rslt: Result<Vec<_>, _> = vec.into_iter().map(|pv| {
+                    T::try_from(pv)
+                }).collect();
+                match rslt {
+                    Err(_) => None,
+                    Ok(values) => Some(values)
+                } 
+            },
+            _ => None,
+        }
+    }
 }
 
 /// A value we can compare and use in database queries.
@@ -265,6 +286,47 @@ impl<'a> From<i32> for ParameterizedValue<'a> {
     fn from(that: i32) -> Self {
         ParameterizedValue::Integer(that as i64)
     }
+}
+
+impl<'a> TryFrom<ParameterizedValue<'a>> for i64 {
+    type Error = Error;
+
+    fn try_from(value: ParameterizedValue<'a>) -> Result<i64, Self::Error> {
+        value.as_i64().ok_or(Error::ConversionError("Not an i64"))
+     }
+}
+
+impl<'a> TryFrom<ParameterizedValue<'a>> for f64 {
+    type Error = Error;
+
+    fn try_from(value: ParameterizedValue<'a>) -> Result<f64, Self::Error> {
+        value.as_f64().ok_or(Error::ConversionError("Not an f64"))
+     }
+}
+
+impl<'a> TryFrom<ParameterizedValue<'a>> for String {
+    type Error = Error;
+
+    fn try_from(value: ParameterizedValue<'a>) -> Result<String, Self::Error> {
+        value.into_string().ok_or(Error::ConversionError("Not a string"))
+     }
+}
+
+impl<'a> TryFrom<ParameterizedValue<'a>> for bool {
+    type Error = Error;
+
+    fn try_from(value: ParameterizedValue<'a>) -> Result<bool, Self::Error> {
+        value.as_bool().ok_or(Error::ConversionError("Not a bool"))
+     }
+}
+
+#[cfg(feature = "chrono-0_4")]
+impl<'a> TryFrom<ParameterizedValue<'a>> for DateTime<Utc> {
+    type Error = Error;
+
+    fn try_from(value: ParameterizedValue<'a>) -> Result<DateTime<Utc>, Self::Error> {
+        value.as_datetime().ok_or(Error::ConversionError("Not a datetime"))
+     }
 }
 
 macro_rules! parameterized_value {
@@ -480,5 +542,66 @@ impl<'a> Comparable<'a> for DatabaseValue<'a> {
             Box::new(left.into()),
             Box::new(right.into()),
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn a_parameterized_value_of_ints_can_be_converted_into_a_vec() {
+        let pv = ParameterizedValue::Array(vec![ParameterizedValue::Integer(1)]);
+    
+        let values: Vec<i64> = pv.into_vec().expect("convert into Vec<i64>");
+
+        assert_eq!(values, vec![1]);
+    }
+
+    #[test]
+    fn a_parameterized_value_of_reals_can_be_converted_into_a_vec() {
+        let pv = ParameterizedValue::Array(vec![ParameterizedValue::Real(1.0)]);
+    
+        let values: Vec<f64> = pv.into_vec().expect("convert into Vec<f64>");
+        
+        assert_eq!(values, vec![1.0]);
+    }
+
+    #[test]
+    fn a_parameterized_value_of_texts_can_be_converted_into_a_vec() {
+        let pv = ParameterizedValue::Array(vec![ParameterizedValue::Text(Cow::from("test"))]);
+    
+        let values: Vec<String> = pv.into_vec().expect("convert into Vec<String>");
+        
+        assert_eq!(values, vec!["test"]);
+    }
+
+    #[test]
+    fn a_parameterized_value_of_booleans_can_be_converted_into_a_vec() {
+        let pv = ParameterizedValue::Array(vec![ParameterizedValue::Boolean(true)]);
+    
+        let values: Vec<bool> = pv.into_vec().expect("convert into Vec<bool>");
+        
+        assert_eq!(values, vec![true]);
+    }
+
+    #[test]
+    fn a_parameterized_value_of_datetimes_can_be_converted_into_a_vec() {
+        let datetime = DateTime::from_str("2019-07-27T05:30:30Z").expect("parsing date/time");
+        let pv = ParameterizedValue::Array(vec![ParameterizedValue::DateTime(datetime)]);
+    
+        let values: Vec<DateTime<Utc>> = pv.into_vec().expect("convert into Vec<DateTime>");
+        
+        assert_eq!(values, vec![datetime]);
+    }
+
+    #[test]
+    fn a_parameterized_value_of_an_array_cant_be_converted_into_a_vec_of_the_wrong_type() {
+        let pv = ParameterizedValue::Array(vec![ParameterizedValue::Integer(1)]);
+    
+        let rslt: Option<Vec<f64>> = pv.into_vec();
+        
+        assert!(rslt.is_none());
     }
 }


### PR DESCRIPTION
Add method `ParameterizedValue::into_vec`.

TODO: 

- [x] Use conversion methods in `TryFrom` implementations.