### PR TITLE
Support CAST expressions

### DIFF
--- a/.buildkite/docker.sh
+++ b/.buildkite/docker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+MYSQL_ROOT_PASSWORD=prisma
+
 docker network create test-net
 docker run --name test-postgres --network test-net \
     -e POSTGRES_PASSWORD=prisma \
@@ -9,7 +11,7 @@ docker run --name test-postgres --network test-net \
 docker run --name test-mysql --network test-net \
     -e MYSQL_USER=prisma \
     -e MYSQL_DATABASE=prisma \
-    -e MYSQL_ROOT_PASSWORD=prisma \
+    -e MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD \
     -e MYSQL_PASSWORD=prisma -d mysql
 
 docker run -w /build --network test-net -v $BUILDKITE_BUILD_CHECKOUT_PATH:/build \
@@ -23,6 +25,7 @@ docker run -w /build --network test-net -v $BUILDKITE_BUILD_CHECKOUT_PATH:/build
     -e TEST_MYSQL_DB=prisma \
     -e TEST_MYSQL_USER=prisma \
     -e TEST_MYSQL_PASSWORD=prisma \
+    -e TEST_MYSQL_ROOT_PASSWORD=$MYSQL_ROOT_PASSWORD \
     prismagraphql/rust-build:latest cargo test
 
 exit_code=$?

--- a/src/ast/function.rs
+++ b/src/ast/function.rs
@@ -1,8 +1,10 @@
 mod aggregate_to_string;
+mod cast;
 mod count;
 mod row_number;
 
 pub use aggregate_to_string::*;
+pub use cast::*;
 pub use count::*;
 pub use row_number::*;
 
@@ -20,6 +22,7 @@ pub struct Function<'a> {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum FunctionType<'a> {
     RowNumber(RowNumber<'a>),
+    Cast(Cast<'a>),
     Count(Count<'a>),
     AggregateToString(AggregateToString<'a>),
 }
@@ -58,4 +61,4 @@ macro_rules! function {
     );
 }
 
-function!(RowNumber, Count, AggregateToString);
+function!(RowNumber, Cast, Count, AggregateToString);

--- a/src/ast/function/cast.rs
+++ b/src/ast/function/cast.rs
@@ -1,0 +1,27 @@
+use crate::ast::DatabaseValue;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Cast<'a> {
+    pub(crate) expr: Box<DatabaseValue<'a>>,
+    pub(crate) tpe: &'a str,
+}
+
+/// Convert an expression of one type to an expression of another type.
+///
+/// ```rust
+/// # use prisma_query::{ast::*, visitor::{Visitor, Sqlite}};
+/// let query = Select::from_table("users").value(cast("3", "INTEGER"));
+/// let (sql, params) = Sqlite::build(query);
+/// assert_eq!("SELECT CAST(? AS INTEGER) FROM `users`", sql);
+/// assert_eq!(&[ParameterizedValue::Text("3".into())], params.as_slice());
+/// ```
+#[inline]
+pub fn cast<'a, T>(expr: T, tpe: &'a str) -> Cast<'a>
+where
+    T: Into<DatabaseValue<'a>>,
+{
+    Cast {
+        expr: Box::new(expr.into()),
+        tpe,
+    }
+}

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -524,6 +524,11 @@ pub trait Visitor<'a> {
                     )
                 }
             }
+            FunctionType::Cast(cast) => format!(
+                "CAST({expr} AS {tpe})",
+                expr = self.visit_database_value(*cast.expr),
+                tpe = cast.tpe
+            ),
             FunctionType::Count(fun_count) => {
                 if fun_count.exprs.is_empty() {
                     String::from("COUNT(*)")


### PR DESCRIPTION
It's the portable way to cast SQL values between types.

Postgres: https://www.postgresql.org/docs/11/sql-expressions.html#SQL-SYNTAX-TYPE-CASTS
SQLite: https://www.sqlite.org/lang_expr.html#castexpr
MySQL: https://dev.mysql.com/doc/refman/5.7/en/cast-functions.html

The CI failure doesn't seem related.