### PR TITLE
Expose TLS-related errors separately from other connection errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -61,7 +61,10 @@ pub enum Error {
     ConnectTimeout,
 
     #[fail(display = "Operation timed out")]
-    Timeout
+    Timeout,
+
+    #[fail(display = "Error opening a TLS connection. {}", message)]
+    TlsError { message: String },
 }
 
 #[cfg(any(


### PR DESCRIPTION
This is meant to enable better error diagnostics in Lift. This also means we now have to handle both cases in the rest of prisma-engine, so I'd like some feedback on that.